### PR TITLE
Add symbol link for the img dir inside public dir

### DIFF
--- a/public/img
+++ b/public/img
@@ -1,0 +1,1 @@
+/home/roryc/work_github/awesome-jbrowse2/img


### PR DESCRIPTION
Hello again :), 

I noticed the images weren't showing up in the GH pages deployment of the site: https://cmdcolin.github.io/awesome-jbrowse2/ 

This commit hopefully fixes it as I was able to reproduce the problem locally: 
```
# images will show
npx vite dev 

# images won't show
npx vite build
npx vite preview
```

To fix, I committed a symbolic link for the img folder to the `public` dir and that seemed to fix things locally at least. 